### PR TITLE
Minor Patch v229

### DIFF
--- a/common/ascension_perks/xvcv_mdlc_ascension_perks.txt
+++ b/common/ascension_perks/xvcv_mdlc_ascension_perks.txt
@@ -519,10 +519,10 @@ oxr_mdlc_ap_distributed_multikernel = {
 }
 oxr_mdlc_ap_mamp = {
 	potential = {
-		# is_machine_empire = yes
-		# NOT = { has_ascension_perk = oxr_mdlc_ap_mamp }
-		# is_individual_machine = no
-		always = no
+		is_machine_empire = yes
+		NOT = { has_ascension_perk = oxr_mdlc_ap_mamp }
+		is_individual_machine = no
+		has_country_flag = oxr_mdlc_ap_mamp_enabled
 	}
 	possible = {
 		# has_technology = tech_robot_assembly_complex

--- a/common/ascension_perks/xvcv_mdlc_ascension_perks.txt
+++ b/common/ascension_perks/xvcv_mdlc_ascension_perks.txt
@@ -519,13 +519,10 @@ oxr_mdlc_ap_distributed_multikernel = {
 }
 oxr_mdlc_ap_mamp = {
 	potential = {
-		# OR = {
-		# 	is_mechanical_empire = yes
-		# 	is_machine_empire = yes
-		# }
-		is_machine_empire = yes
-		NOT = { has_ascension_perk = oxr_mdlc_ap_mamp }
-		is_individual_machine = no
+		# is_machine_empire = yes
+		# NOT = { has_ascension_perk = oxr_mdlc_ap_mamp }
+		# is_individual_machine = no
+		always = no
 	}
 	possible = {
 		# has_technology = tech_robot_assembly_complex

--- a/common/button_effects/xvcv_mdlc_button_effects_leader_making_main_customgui.txt
+++ b/common/button_effects/xvcv_mdlc_button_effects_leader_making_main_customgui.txt
@@ -376,7 +376,8 @@ xvcv_mdlc_leader_making_start_button_effect = {
                 }
                 #then the skill level and other things at last
                 event_target:xvcv_mdlc_leader_making_target = {
-                    set_skill = value:xvcv_mdlc_leader_making_skill_level
+                    log = "Going to make leader at level \\[root.xvcv_mdlc_leader_making_skill_level]"
+                    set_skill = root.xvcv_mdlc_leader_making_skill_level
                     set_leader_flag = xvcv_mdlc_leader_making_target_leader
                 }
                 count = xvcv_mdlc_leader_making_start_number

--- a/common/decisions/oxr_mdlc_mamp_decisions.txt
+++ b/common/decisions/oxr_mdlc_mamp_decisions.txt
@@ -94,18 +94,14 @@ oxr_mdlc_decision_mamp_enable_auto_construction_cat_1 = {
 		custom_tooltip = oxr_mdlc_decision_mamp_enable_auto_construction_cat_1_tooltip
 		hidden_effect = {
 			if = {
-				limit = { 
-					has_modifier = oxr_mdlc_mamp_auto_construction_was_disabled_during_event
-				}
+				limit = { has_modifier = oxr_mdlc_mamp_auto_construction_was_disabled_during_event }
 				remove_modifier = oxr_mdlc_mamp_auto_construction_was_disabled_during_event
 			}
 			add_modifier = { modifier = oxr_mdlc_mamp_auto_construction_active }
 			oxr_mdlc_mamp_planet_set_autoconstruction_cat_level = { LEVEL = 1 }
 			# If there's a construction in progress, don't trigger another one
 			if = {
-				limit = {
-					oxr_mdlc_mamp_planet_constructions_are_in_progress = no
-				}
+				limit = { oxr_mdlc_mamp_planet_constructions_are_in_progress = no }
 				planet_event = { id = oxr_mdlc_mamp.1000 }
 				log = "Player activated MAMP auto-construction L1 on \\[This.GetName]"
 			}
@@ -137,13 +133,12 @@ oxr_mdlc_decision_mamp_deactivate_auto_construction_cat_1 = {
 		custom_tooltip = oxr_mdlc_mamp_planet_end_autoconstruction_cat_level.1
 		hidden_effect = {
 			remove_modifier = oxr_mdlc_mamp_auto_construction_active
-		set_variable = {
-			which = oxr_mdlc_mamp_auto_construction_cat_level
-			value = 0
+			set_variable = {
+				which = oxr_mdlc_mamp_auto_construction_cat_level
+				value = 0
+			}
+			log = "Player deactivated MAMP auto-construction L1 on \\[This.GetName]"
 		}
-		log = "Player deactivated MAMP auto-construction L1 on \\[This.GetName]"
-		}
-		
 	}
 }
 
@@ -182,24 +177,21 @@ oxr_mdlc_decision_mamp_enable_auto_construction_cat_2 = {
 		custom_tooltip = oxr_mdlc_decision_mamp_enable_auto_construction_cat_2_tooltip
 		hidden_effect = {
 			if = {
-				limit = { 
-					has_modifier = oxr_mdlc_mamp_auto_construction_was_disabled_during_event
-				}
+				limit = { has_modifier = oxr_mdlc_mamp_auto_construction_was_disabled_during_event }
 				remove_modifier = oxr_mdlc_mamp_auto_construction_was_disabled_during_event
 			}
 			add_modifier = { modifier = oxr_mdlc_mamp_auto_construction_active }
 			oxr_mdlc_mamp_planet_set_autoconstruction_cat_level = { LEVEL = 2 }
 			# If there's a construction in progress, don't trigger another one
 			if = {
-				limit = {
-					oxr_mdlc_mamp_planet_constructions_are_in_progress = no
-				}
+				limit = { oxr_mdlc_mamp_planet_constructions_are_in_progress = no }
 				planet_event = { id = oxr_mdlc_mamp.1000 }
 				log = "Player activated MAMP auto-construction L2 on \\[This.GetName]"
 			}
 			else = {
 				log = "Player re-activated MAMP auto-construction L2 on \\[This.GetName] while mamp was being built."
 			}
+		}
 	}
 }
 

--- a/common/districts/xvcv_mdlc_pc_ring_auto_districts.txt
+++ b/common/districts/xvcv_mdlc_pc_ring_auto_districts.txt
@@ -222,7 +222,6 @@ xvcv_mdlc_pc_ringworld_machine_auto_industrial = {
 		upkeep = {
 			energy = @rw_maintenance
 			volatile_motes = @rw_maintenance_sr
-			minerals = 120 # 60 x 2 for alloys and goods
 		}
 		upkeep = {
 			trigger = {
@@ -233,12 +232,71 @@ xvcv_mdlc_pc_ringworld_machine_auto_industrial = {
 			}
 			energy = 4
 		}
+		# Default, if no designation
 		produces = {
-			consumer_goods = 60
+			consumer_goods = 60  # uses 30 minerals
 			alloys = 30
 		}
-	}
-		
+		# Foundry designation
+		produces = {
+			trigger = {
+				OR = {
+					has_designation = col_capital_foundry
+					has_designation = col_ecu_foundry
+					has_designation = col_foundry
+				}
+			}
+			alloys = 30  # total of 60, equal to ECU alloys district
+			consumer_goods = -60
+		}
+		upkeep = {
+			trigger = {
+				OR = {
+					has_designation = col_capital_foundry
+					has_designation = col_ecu_foundry
+					has_designation = col_foundry
+				}
+				exists = owner
+				owner = { is_catalytic_empire = no }
+			}
+			minerals = 60
+		}
+		upkeep = {
+			trigger = {
+				OR = {
+					has_designation = col_capital_foundry
+					has_designation = col_ecu_foundry
+					has_designation = col_foundry
+				}
+				exists = owner
+				owner = { is_catalytic_empire = yes }
+			}
+			food = 90
+			minerals = -60
+		}
+		# Factory designation
+		produces = {
+			trigger = {
+				OR = {
+					has_designation = col_capital_factory
+					has_designation = col_ecu_factory
+					has_designation = col_factory
+				}
+			}
+			alloys = -15
+			consumer_goods = 90  # total of 120, equal to ECU goods district
+		}
+		upkeep = {
+			trigger = {
+				OR = {
+					has_designation = col_capital_factory
+					has_designation = col_ecu_factory
+					has_designation = col_factory
+				}
+			}
+			minerals = 60
+		}
+	}	
 }
 
 xvcv_mdlc_pc_ringworld_machine_auto_farming = {

--- a/common/scripted_effects/oxr_mdlc_scripted_effects_mamp.txt
+++ b/common/scripted_effects/oxr_mdlc_scripted_effects_mamp.txt
@@ -145,7 +145,8 @@ oxr_mdlc_mamp_construct_cat_1_pop = {
 	random_owned_pop = {
 		limit = {
 			species = {
-				is_archetype = MACHINE
+				# is_archetype = MACHINE
+				has_trait = trait_machine_unit
 				NOT = { is_archetype = OXR_MDLC_MAMP }
 			}
 		}
@@ -169,7 +170,8 @@ oxr_mdlc_mamp_planet_kill_pop_for_frame = {
 	random_owned_pop = {
 		limit = {
 			species = {
-				is_archetype = MACHINE
+				# is_archetype = MACHINE
+				has_trait = trait_machine_unit
 				NOT = { is_archetype = OXR_MDLC_MAMP }
 			}
 			# NOT = { has_job_category = ruler }
@@ -201,5 +203,133 @@ oxr_mdlc_mamp_planet_set_autoconstruction_cat_level = {
 	set_variable = {
 		which = oxr_mdlc_mamp_auto_construction_cat_level
 		value = $LEVEL$
+	}
+}
+
+# oxr_mdlc_mamp_planet_reset_frame_habitability = {
+# 	# Change pop's habitability based on planet type
+# 	any_owned_pop = {
+# 		oxr_mdlc_mamp_pop_remove_habitability_preference = yes
+# 	}
+# 	oxr_mdlc_mamp_pop_remove_habitability_preference = yes
+# }
+
+oxr_mdlc_mamp_pop_remove_habitability_preference = {
+	if = {
+		limit = { 
+			last_created_pop = {
+				species = { is_archetype = OXR_MDLC_MAMP }
+			}
+		}
+		if = {
+			limit = {
+				species = { has_trait = trait_dry_planet_preference }
+			}
+			modify_species = { remove_trait = trait_dry_planet_preference }
+		}
+		# vanilla, wet
+		if = {
+			limit = {
+				species = { has_trait = trait_wet_planet_preference }
+			}
+			modify_species = { remove_trait = trait_wet_planet_preference }
+		}
+		# vanilla, frozen
+		if = {
+			limit = {
+				species = { has_trait = trait_frozen_planet_preference }
+			}
+			modify_species = { remove_trait = trait_frozen_planet_preference }
+		}
+		# custom, dry
+		if = {
+			limit = {
+				species = { has_trait = oxr_mdlc_trait_dry_planet_preference }
+			}
+			modify_species = { remove_trait = oxr_mdlc_trait_dry_planet_preference }
+		}
+		# custom, wet
+		if = {
+			limit = {
+				species = { has_trait = oxr_mdlc_trait_wet_planet_preference }
+			}
+			modify_species = { remove_trait = oxr_mdlc_trait_wet_planet_preference }
+		}
+		# custom, frozen
+		if = {
+			limit = {
+				species = { has_trait = oxr_mdlc_trait_frozen_planet_preference }
+			}
+			modify_species = { remove_trait = oxr_mdlc_trait_frozen_planet_preference }
+		}
+	}
+
+}
+oxr_mdlc_mamp_pop_change_habitability_preference = {
+	if = {
+		limit = { 
+			random_owned_pop = {
+				species = { is_archetype = OXR_MDLC_MAMP }
+			}
+		}
+		random_owned_pop = {
+			modify_species = {
+				ideal_planet_class = root
+			}
+		}
+	}
+}
+
+oxr_mdlc_mamp_planet_update_all_frames_habitability = {
+	every_owned_pop = {
+		limit = {
+			species = { is_archetype = OXR_MDLC_MAMP }
+		}
+		# vanilla, dry
+		if = {
+			limit = {
+				species = { has_trait = trait_dry_planet_preference }
+			}
+			modify_species = { remove_trait = trait_dry_planet_preference }
+		}
+		# vanilla, wet
+		if = {
+			limit = {
+				species = { has_trait = trait_wet_planet_preference }
+			}
+			modify_species = { remove_trait = trait_wet_planet_preference }
+		}
+		# vanilla, frozen
+		if = {
+			limit = {
+				species = { has_trait = trait_frozen_planet_preference }
+			}
+			modify_species = { remove_trait = trait_frozen_planet_preference }
+		}
+		# custom, dry
+		if = {
+			limit = {
+				species = { has_trait = oxr_mdlc_trait_dry_planet_preference }
+			}
+			modify_species = { remove_trait = oxr_mdlc_trait_dry_planet_preference }
+		}
+		# custom, wet
+		if = {
+			limit = {
+				species = { has_trait = oxr_mdlc_trait_wet_planet_preference }
+			}
+			modify_species = { remove_trait = oxr_mdlc_trait_wet_planet_preference }
+		}
+		# custom, frozen
+		if = {
+			limit = {
+				species = { has_trait = oxr_mdlc_trait_frozen_planet_preference }
+			}
+			modify_species = { remove_trait = oxr_mdlc_trait_frozen_planet_preference }
+		}
+		# Use built-in .. will this stick?
+		modify_species = {
+			ideal_planet_class = root
+		}
 	}
 }

--- a/common/scripted_effects/xvcv_mdlc_scripted_effects_leader_making_customgui.txt
+++ b/common/scripted_effects/xvcv_mdlc_scripted_effects_leader_making_customgui.txt
@@ -163,6 +163,10 @@ xvcv_mdlc_leader_making_clear_values_effect = {
         which = xvcv_mdlc_leader_making_start_number
         value = 1
     }
+    set_variable = {
+        which = xvcv_mdlc_leader_making_skill_level
+        value = 1
+    }
 
     #commander
     if = {

--- a/events/xvcv_mdlc_events_merchant.txt
+++ b/events/xvcv_mdlc_events_merchant.txt
@@ -569,6 +569,39 @@ country_event = {
 		}
 	}
 	option = {
+		name = xvcv_mdlc_reset_evt_window
+		custom_tooltip = xvcv_mdlc_reset_evt_window_desc
+		hidden_effect = {
+			remove_country_flag = xvcv_mdlc_civic_trading_machine_target_selection_locked #unlock targets #check the above scripted effect too
+			#clear all temporally selected targets
+			random_country = {
+				limit = { has_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_1_@root }
+				remove_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_1_@root
+			}
+			random_country = {
+				limit = { has_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_2_@root }
+				remove_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_2_@root
+			}
+			random_country = {
+				limit = { has_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_3_@root }
+				remove_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_3_@root
+			}
+			random_country = {
+				limit = { has_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_4_@root }
+				remove_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_4_@root
+			}
+			random_country = {
+				limit = { has_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_5_@root }
+				remove_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_5_@root
+			}
+			random_country = {
+				limit = { has_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_6_@root }
+				remove_country_flag = xvcv_mdlc_civic_trading_machine_temporally_selected_target_6_@root
+			}
+		}
+		hidden_effect = { country_event = { id = xvcv_mdlc.10 } }
+	}
+	option = {
 		name = xvcv_mdlc_close_evt_window
 		default_hide_option = yes
 		hidden_effect = {

--- a/localisation/english/xvcv_mdlc_l_english.yml
+++ b/localisation/english/xvcv_mdlc_l_english.yml
@@ -1514,6 +1514,8 @@
 
  ### Events ###
  xvcv_mdlc_close_evt_window:0 "Close Window"
+ xvcv_mdlc_reset_evt_window:0 "Refresh Trade Route Choices"
+ xvcv_mdlc_reset_evt_window_desc:0 "Picking this option will present a different set of options to make trade routes with, if there are more empires available."
 
  xvcv_mdlc_no_more_empire_with_required_conditions.tooltip.fail:0 "§RThere is no more empire that fulfills the required conditions.§!"
  xvcv_mdlc.10.name:0 "Trade Route Control"

--- a/mre_code_tools/generate_traits_gui_and_effects.py
+++ b/mre_code_tools/generate_traits_gui_and_effects.py
@@ -655,10 +655,14 @@ def gen_xvcv_mdlc_core_modifying_reset_traits_button_effect_lines(input_files_li
                     effect_contents_items.append(
                         ruler_effect_line.format(trait_name=trait_name, rarity=rarity)
                     )
+    subclass_effect_line = (
+        "if = {{ limit = {{ has_trait = {trait_name} }} remove_trait = {trait_name} prev ="
+        " {{ xvcv_mdlc_core_modifying_trait_return_cost_effect = yes }} }}"
+    )
     for subclass in LEADER_SUBCLASSES:
         alt_modifier = ""
         effect_contents_items.append(
-            ruler_effect_line.format(trait_name=subclass, alt_modifier=alt_modifier)
+            subclass_effect_line.format(trait_name=subclass, alt_modifier=alt_modifier)
         )
     return "\n".join(effect_contents_items)
 

--- a/mre_code_tools/mre_common_vars.py
+++ b/mre_code_tools/mre_common_vars.py
@@ -269,6 +269,7 @@ TRAITS_TO_EXCLUDE = {
     "leader_trait_towel":1,  # given via event,
     "leader_trait_percussive_maintainer":1,  #given via event ancrel.12005
     "leader_trait_intemporal":1,  #given via event,
+    "leader_trait_robotist":1,  # just annoying to deal with code-wise
 }
 
 """ Our trick to prepend mre_ to modifier names doesn't always work automatically.


### PR DESCRIPTION
Bugfixes:
- Fix missing closing brace
- Fix leaders starting at lvl 1 no matter what level is selected
- Auto-Ringworld industrial district produces goods or alloys based on designation
- Use Machine trait to identify pops for converting MAMP, not machine species

Gameplay: Put MAMP ascension perk behind a country flag while it is being reworked behind the scenes to be more competitive with other APs. Thanks everyone for your feedback & patience so far. To playtest this AP do `effect = { set_country_flag = oxr_mdlc_ap_mamp_enabled }` in the in-game console.

Guest contribution: Legit-Rikk: Trade control menu improvement