### PR TITLE
MREC Patch 2.3.2

### DIFF
--- a/common/traits/rikk_mdlc_species_traits_extended.txt
+++ b/common/traits/rikk_mdlc_species_traits_extended.txt
@@ -291,15 +291,10 @@ rikk_mdlc_trait_robotic_constant_growth = {
 	cost = 3
 	inline_script = trait/rikk_extended
 
-	species_possible_remove = {
-		always = no
-	}
-	species_possible_merge_add = {
-		always = no
-	}
-	species_possible_merge_remove = {
-		always = no
-	}
+	species_possible_add = { always = no }
+	species_possible_remove = { always = no }
+	species_possible_merge_add = { always = no }
+	species_possible_merge_remove = { always = no }
 
 	modifier = {
 		pop_housing_usage_add = -0.5
@@ -326,15 +321,10 @@ rikk_mdlc_trait_robotic_ai_splitting = {
 	cost = 2
 	inline_script = trait/rikk_extended
 
-	species_possible_remove = {
-		always = no
-	}
-	species_possible_merge_add = {
-		always = no
-	}
-	species_possible_merge_remove = {
-		always = no
-	}
+	species_possible_add = { always = no }
+	species_possible_remove = { always = no }
+	species_possible_merge_add = { always = no }
+	species_possible_merge_remove = { always = no }
 
 	modifier = {
 		#New Leaders start with levels equal to ruler level


### PR DESCRIPTION
Legit-Rikk:
- Fixed the constant_growth (nanomachines) and AI_splitting trait being able to be added in-game, condensed the code for the always = no section