### PR TITLE
Add missing world machine building category notes

### DIFF
--- a/localisation/english/oxr_mdlc_l_english_origin_world_machine.yml
+++ b/localisation/english/oxr_mdlc_l_english_origin_world_machine.yml
@@ -115,10 +115,10 @@
  oxr_mdlc_world_machines_building_auto_factory_1_desc: "This facility produces the consumable items necessary to pops for daily living and function, such as garments, cleaning supplies, and Zro Cola. Additionally it produces supplies on demand used by various jobs, like tools, containers, chemicals, fabrics, and handheld computation devices.$oxr_mdlc_mod_tag$$oxr_mdlc_world_machine_building_category_note$"
  # Factory 2 - TODO
  oxr_mdlc_world_machines_building_auto_factory_2: "Auto-Factory 2"
- oxr_mdlc_world_machines_building_auto_factory_2_desc: "$oxr_mdlc_world_machines_building_auto_factory_1_desc$$oxr_mdlc_mod_tag$$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_factory_2_desc: "$oxr_mdlc_world_machines_building_auto_factory_1_desc$"
  # Factory 3 - TODO
  oxr_mdlc_world_machines_building_auto_factory_3: "Auto-Factory 3"
- oxr_mdlc_world_machines_building_auto_factory_3_desc: "$oxr_mdlc_world_machines_building_auto_factory_1_desc$$oxr_mdlc_mod_tag$$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_factory_3_desc: "$oxr_mdlc_world_machines_building_auto_factory_1_desc$"
  # Factory Boost 1 - TODO
  oxr_mdlc_world_machines_building_auto_factory_boost_1: "$oxr_gear$ Auto-Factory Supplemental"
  oxr_mdlc_world_machines_building_auto_factory_boost_1_desc: "A standard single-level consumer goods factory.$oxr_mdlc_mod_tag$$oxr_mdlc_world_machine_building_category_note$"

--- a/localisation/english/oxr_mdlc_l_english_origin_world_machine.yml
+++ b/localisation/english/oxr_mdlc_l_english_origin_world_machine.yml
@@ -139,7 +139,7 @@
  oxr_mdlc_world_machines_building_auto_archaeo_refinery_desc: "Various artifacts undergo a decomposition process during which their components are desynthesized alongside large batches of various minerals in an arc furnace; this process yields raw strategic resources for direct capture.$oxr_mdlc_mod_tag$$oxr_mdlc_world_machine_building_category_note$"
 
  oxr_mdlc_world_machines_building_auto_nanite_transmuter: "$oxr_gear$ Auto-$building_nanite_transmuter$"
- oxr_mdlc_world_machines_building_auto_nanite_transmuter_desc: "Nanites are used at a particle level to rapidly assemble molecular structures for strategic resources. This energy-intensive process makes strategic resource production more mobile, but at the same time burns out the nanites in this demanding and volatile process."
+ oxr_mdlc_world_machines_building_auto_nanite_transmuter_desc: "Nanites are used at a particle level to rapidly assemble molecular structures for strategic resources. This energy-intensive process makes strategic resource production more mobile, but at the same time burns out the nanites in this demanding and volatile process. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
  #### MILITARY ####
  oxr_mdlc_world_machines_building_maintenance_legion: "$oxr_gear$ Auto-Security Maintenance"
@@ -152,28 +152,28 @@
  #### RESEARCH ####
 # lab 1 - IMPLEMENTED
  oxr_mdlc_world_machines_building_fractal_sanitizer: "$oxr_gear$ Auto-Fractal Algorithm 1: Sanitizer"
- oxr_mdlc_world_machines_building_fractal_sanitizer_desc: "This computing processing station monitors and corrects errors in fractal algorithm generation, to ensure stability in research procedures.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_fractal_sanitizer_desc: "This computing processing station monitors and corrects errors in fractal algorithm generation, to ensure stability in research procedures. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # lab 2 - IMPLEMENTED
  oxr_mdlc_world_machines_building_fractal_sanitizer_2: "Auto-Fractal Algorithm 2: Mutator"
- oxr_mdlc_world_machines_building_fractal_sanitizer_2_desc: "This advanced computing processing station calculates efficient mutations in fractal algorithm generation, further improving stability and output in research procedures.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_fractal_sanitizer_2_desc: "This advanced computing processing station calculates efficient mutations in fractal algorithm generation, further improving stability and output in research procedures. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # lab 3 - IMPLEMENTED
  oxr_mdlc_world_machines_building_fractal_sanitizer_3: "Auto-Fractal Algorithm 3: Condenser"
- oxr_mdlc_world_machines_building_fractal_sanitizer_3_desc: "This large, advanced computing processing station synthesizes patterns in fractal algorithm generation, condensing them to be more optimized, further improving stability and output in research procedures.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_fractal_sanitizer_3_desc: "This large, advanced computing processing station synthesizes patterns in fractal algorithm generation, condensing them to be more optimized, further improving stability and output in research procedures. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # lab 4 - IMPLEMENTED
  oxr_mdlc_world_machines_building_fractal_sanitizer_4: "Auto-Fractal Algorithm 4: Multiplex"
- oxr_mdlc_world_machines_building_fractal_sanitizer_4_desc: "The entire facility is one single, massively parallel fractal algorithm processing center. It has sixty four bidirectional transmission towers, its own integrated cooling, and two backup generators.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_fractal_sanitizer_4_desc: "The entire facility is one single, massively parallel fractal algorithm processing center. It has sixty four bidirectional transmission towers, its own integrated cooling, and two backup generators. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # Research Institute - TODO
  oxr_mdlc_world_machines_building_central_data_router: "$oxr_gear$ Central Data Router"
- oxr_mdlc_world_machines_building_central_data_router_desc: "This is one of several large information infrastructure centers distributed throughout the planet, which extends the range at which data can be transmitted, and provides redundancy for the entire planetary network.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_central_data_router_desc: "This is one of several large information infrastructure centers distributed throughout the planet, which extends the range at which data can be transmitted, and provides redundancy for the entire planetary network. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # Supercomputer - IMPLEMENTED
  oxr_mdlc_world_machines_building_cold_storage_datacenter: "$oxr_gear$ Cold Storage Datacenter"
- oxr_mdlc_world_machines_building_cold_storage_datacenter_desc: "This datacenter contains terabytes of system logs, sensor data, and kernel dumpfiles. The main feature of the datacenter is its log analysis model, which can process up to 120 million requests per second from connected Fractal Algorithm stations and any active Data Routers.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_cold_storage_datacenter_desc: "This datacenter contains terabytes of system logs, sensor data, and kernel dumpfiles. The main feature of the datacenter is its log analysis model, which can process up to 120 million requests per second from connected Fractal Algorithm stations and any active Data Routers. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # Archaeostudies faculty - IMPLEMENTED
  oxr_mdlc_world_machines_building_archaeostudies_recombinator: "$oxr_gear$ Errata Recombinator"
- oxr_mdlc_world_machines_building_archaeostudies_recombinator_desc: "This facility focuses on training learning models to derive functional value from arbitrary alien artifacts retrieved from any variety of sources, while continuously constructing and improving an ontology to also facilitate discovering meaning and intent.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_archaeostudies_recombinator_desc: "This facility focuses on training learning models to derive functional value from arbitrary alien artifacts retrieved from any variety of sources, while continuously constructing and improving an ontology to also facilitate discovering meaning and intent. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # Fractal Signal Inverter
  oxr_mdlc_world_machines_building_fractal_fpga: "$oxr_gear$ Auto-Fractal Programmable Gate"
- oxr_mdlc_world_machines_building_fractal_fpga_desc: "This facility reconfigures all research output to match the CPU colony designation by transposing all other research processes to the desired field. Having focused all planetary research, additional signal harmony raises the overall research output for that field."
+ oxr_mdlc_world_machines_building_fractal_fpga_desc: "This facility reconfigures all research output to match the CPU colony designation by transposing all other research processes to the desired field. Having focused all planetary research, additional signal harmony raises the overall research output for that field. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_building_fractal_fpga_focus_phrase: "All planetary research output is being reprogrammed to"
  oxr_mdlc_world_machines_building_fractal_fpga_focus_engineering: "§Y$oxr_mdlc_world_machines_building_fractal_fpga_focus_phrase$ £engineering_research£ $engineering_research$§!"
  oxr_mdlc_world_machines_building_fractal_fpga_focus_society: "§Y$oxr_mdlc_world_machines_building_fractal_fpga_focus_phrase$ £society_research£ $society_research$§!"
@@ -187,129 +187,129 @@
  #### RESOURCE ####
 # building_hydroponics_farm
  oxr_mdlc_world_machines_auto_farm_1: "$oxr_gear$ Auto-Nutrient Vat"
- oxr_mdlc_world_machines_auto_farm_1_desc: "This facility grows a variety of nutrient-rich algae in large tanks, to be consumed by biological life forms. The output is synthesized into a syrup which can be directly ingested, or absorbed via membrane.$oxr_mdlc_mod_tag$$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_auto_farm_1_desc: "This facility grows a variety of nutrient-rich algae in large tanks, to be consumed by biological life forms. The output is synthesized into a syrup which can be directly ingested, or absorbed via membrane. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # AUTO-FARM
  oxr_mdlc_world_machines_auto_farm_2: "Auto-Nutrient Vat 2"
- oxr_mdlc_world_machines_auto_farm_2_desc: "This building houses the standard array of nutrient-rich algae vats, with improved lighting and cleaning equipment for faster production cycles, resulting in greater production."
+ oxr_mdlc_world_machines_auto_farm_2_desc: "This building houses the standard array of nutrient-rich algae vats, with improved lighting and cleaning equipment for faster production cycles, resulting in greater production. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_farm_3: "Auto-Nutrient Vat 3"
- oxr_mdlc_world_machines_auto_farm_3_desc: "Algae vats are integrated with aquaculture for higher nutrient output. The end result is no longer a syrup but dehydrated cubes that have a much longer shelf-life."
+ oxr_mdlc_world_machines_auto_farm_3_desc: "Algae vats are integrated with aquaculture for higher nutrient output. The end result is no longer a syrup but dehydrated cubes that have a much longer shelf-life. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_farm_4: "Auto-Nutrient Vat 4"
- oxr_mdlc_world_machines_auto_farm_4_desc: "A large facility which integrates a variety of food production sources, and makes use of genetically modified organisms for even higher nutrient yields."
+ oxr_mdlc_world_machines_auto_farm_4_desc: "A large facility which integrates a variety of food production sources, and makes use of genetically modified organisms for even higher nutrient yields. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_farm_5: "Auto-Nutrient Vat 5"
- oxr_mdlc_world_machines_auto_farm_5_desc: "A large production facility which makes use of tightly integrated biomass production systems and also is equipped with recyclers for breaking down decommissioned organic content into its constituent parts for re-use."
+ oxr_mdlc_world_machines_auto_farm_5_desc: "A large production facility which makes use of tightly integrated biomass production systems and also is equipped with recyclers for breaking down decommissioned organic content into its constituent parts for re-use. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # Auto-mining
  oxr_mdlc_world_machines_auto_mine_1: "$oxr_gear$ Auto-Bore 1"
- oxr_mdlc_world_machines_auto_mine_1_desc: "A minimal automated borehole site for mineral extraction.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_mine_1_desc: "A minimal automated borehole site for mineral extraction. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_mine_2: "Auto-Bore 2"
- oxr_mdlc_world_machines_auto_mine_2_desc: "A standard automated borehole site for mineral extraction, which uses more durable drill bits.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_mine_2_desc: "A standard automated borehole site for mineral extraction, which uses more durable drill bits. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_mine_3: "Auto-Bore 3"
- oxr_mdlc_world_machines_auto_mine_3_desc: "An standard automated borehole site for mineral extraction with upgraded power output.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_mine_3_desc: "An standard automated borehole site for mineral extraction with upgraded power output. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_mine_4: "Auto-Bore 4"
- oxr_mdlc_world_machines_auto_mine_4_desc: "A large automated borehole site for mineral extraction, with upgraded power output and a triple-bit bore.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_mine_4_desc: "A large automated borehole site for mineral extraction, with upgraded power output and a triple-bit bore. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_mine_5: "Auto-Bore 5"
- oxr_mdlc_world_machines_auto_mine_5_desc: "An extensive automated borehole site for mineral extraction utilizing a combination of high-pressure drilling techniques and extensive debris removal infrastructure to maximize output.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_mine_5_desc: "An extensive automated borehole site for mineral extraction utilizing a combination of high-pressure drilling techniques and extensive debris removal infrastructure to maximize output. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # Auto-Energy
  oxr_mdlc_world_machines_auto_generator_1: "$oxr_gear$ Auto-Generator 1"
- oxr_mdlc_world_machines_auto_generator_1_desc: "A minimal reactor site for energy production.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_generator_1_desc: "A minimal reactor site for energy production. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_generator_2: "Auto-Generator 2"
- oxr_mdlc_world_machines_auto_generator_2_desc: "A standard reactor site for energy production, with an upgraded cooling system.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_generator_2_desc: "A standard reactor site for energy production, with an upgraded cooling system. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_generator_3: "Auto-Generator 3"
- oxr_mdlc_world_machines_auto_generator_3_desc: "A standard reactor site for energy production, with upgraded cooling and larger fuel rods.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_generator_3_desc: "A standard reactor site for energy production, with upgraded cooling and larger fuel rods. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_generator_4: "Auto-Generator 4"
- oxr_mdlc_world_machines_auto_generator_4_desc: "A large reactor site for energy production, with two distinct cores, vertical cooling towers.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_generator_4_desc: "A large reactor site for energy production, with two distinct cores, vertical cooling towers. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_generator_5: "Auto-Generator 5"
- oxr_mdlc_world_machines_auto_generator_5_desc: "An extensive reactor site for energy production, with an array of high-speed flywheels, high-capacity energy storage banks, including power amplifiers for maximum output.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_generator_5_desc: "An extensive reactor site for energy production, with an array of high-speed flywheels, high-capacity energy storage banks, including power amplifiers for maximum output. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
  oxr_mdlc_world_machines_auto_energy_grid_1: "$oxr_gear$ Auto-Power Grid"
- oxr_mdlc_world_machines_auto_energy_grid_1_desc: "Automated energy substation increases generator district and building output with power routing algorithms and improved load balancing protocols.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_energy_grid_1_desc: "Automated energy substation increases generator district and building output with power routing algorithms and improved load balancing protocols. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_auto_energy_grid_2: "Auto-Power Grid 2"
- oxr_mdlc_world_machines_auto_energy_grid_2_desc: "Advanced automated energy substation increases generator district and building output with power routing algorithms and improved load balancing protocols.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_auto_energy_grid_2_desc: "Advanced automated energy substation increases generator district and building output with power routing algorithms and improved load balancing protocols. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
  oxr_mdlc_world_machines_biofuel_refit_1: "$oxr_gear$ Auto-Power Biofuel Refit"
- oxr_mdlc_world_machines_biofuel_refit_1_desc: "Due to efficiency limitations with biofuels, twice as much input is required to achieve the same output as standard space-age power generation methods.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_world_machines_biofuel_refit_1_desc: "Due to efficiency limitations with biofuels, twice as much input is required to achieve the same output as standard space-age power generation methods. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  oxr_mdlc_world_machines_biofuel_refit_1_tooltip: "\nReprograms all generator buildings and districts to use £food£ §Gbiofuels§! as inputs for power generation."
  oxr_mdlc_world_machines_biofuel_refit_1.active_effect: "§YProducing £energy£ with§! £food£ §Gbiofuels§!."
 
 # building_food_processing_facility
  oxr_mdlc_world_machines_building_auto_farm_logistics: "$oxr_gear$ Auto-Nutrient Vat Boosters"
- oxr_mdlc_world_machines_building_auto_farm_logistics_desc: "This facility produces and pumps potent synthetic growth hormones to auto-nutrient machinery, increasing district biomass output.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_farm_logistics_desc: "This facility produces and pumps potent synthetic growth hormones to auto-nutrient machinery, increasing district biomass output. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_food_processing_center - TODO
  oxr_mdlc_world_machines_building_auto_farm_logistics_2: "Auto-Nutrient Finishing Annex"
- oxr_mdlc_world_machines_building_auto_farm_logistics_2_desc: "The output of auto-farm districts is automatically shipped to this finishing facility, where the biomass is further refined, artificial nutrients are sprayed on, and inert fillers are mixed in to increase the total volume of output.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_farm_logistics_2_desc: "The output of auto-farm districts is automatically shipped to this finishing facility, where the biomass is further refined, artificial nutrients are sprayed on, and inert fillers are mixed in to increase the total volume of output. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_baol_organic_plant -- this cant be built on machine worlds, so there should not be an alternative for World Machines
 # building_mineral_purification_plant - IMPLEMENTED
  oxr_mdlc_world_machines_building_auto_mining_support: "$oxr_gear$ Auto-Bore Hub"
- oxr_mdlc_world_machines_building_auto_mining_support_desc: "This facility houses several large extractors with refined sensor equipment for more efficiently processing raw ore into finished minerals. Additionally, this facility installation provides additional transport tunnels and several cars to each Auto-Mine, for getting ore to the finishing stages more quickly.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_mining_support_desc: "This facility houses several large extractors with refined sensor equipment for more efficiently processing raw ore into finished minerals. Additionally, this facility installation provides additional transport tunnels and several cars to each Auto-Mine, for getting ore to the finishing stages more quickly. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_mineral_purification_hub - IMPLEMENTED
  oxr_mdlc_world_machines_building_auto_mining_support_2: "Auto-Bore Annex"
- oxr_mdlc_world_machines_building_auto_mining_support_2_desc: "This facility has complex, sensitive ore extractors for faster refining, large dedicated transport tubes for improving Auto-Mine infrastructure, and upgrades all mining district drills to be larger, more heat-resistant, and durable.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_mining_support_2_desc: "This facility has complex, sensitive ore extractors for faster refining, large dedicated transport tubes for improving Auto-Mine infrastructure, and upgrades all mining district drills to be larger, more heat-resistant, and durable. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
 # building_energy_grid - TODO
  oxr_mdlc_world_machines_building_energy_grid: "Charge Controller"
- oxr_mdlc_world_machines_building_energy_grid_desc: "This array of charge controllers directs energy from generators to the vast battery banks distributed around the planet, at strategic points. Additionally, grid performance is improved with more sophisticated power routing models.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_energy_grid_desc: "This array of charge controllers directs energy from generators to the vast battery banks distributed around the planet, at strategic points. Additionally, grid performance is improved with more sophisticated power routing models. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_energy_nexus - TODO
  oxr_mdlc_world_machines_building_energy_grid_2: "Auto-Energy Nexus"
- oxr_mdlc_world_machines_building_energy_grid_desc: "This large array of charge controllers directs energy from generators to the vast battery banks distributed around the planet, at strategic points. Additionally, grid performance is greatly improved with more sophisticated power routing models.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_energy_grid_desc: "This large array of charge controllers directs energy from generators to the vast battery banks distributed around the planet, at strategic points. Additionally, grid performance is greatly improved with more sophisticated power routing models. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_resource_silo - TODO
  oxr_mdlc_world_machines_building_underground_storage: "Underground Warehouse"
- oxr_mdlc_world_machines_building_underground_storage_desc: "This warehouse contains a variety of storage methods to hold additional resources in reserve, for example: massive battery banks to store energy, deep pits for minerals, dehydration facilities for long-term food storage, and humidity-controlled storage for alloys.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_underground_storage_desc: "This warehouse contains a variety of storage methods to hold additional resources in reserve, for example: massive battery banks to store energy, deep pits for minerals, dehydration facilities for long-term food storage, and humidity-controlled storage for alloys. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_bio_reactor - TODO
  oxr_mdlc_world_machines_building_biowaste_harvester: "Bio-Gas Digester"
- oxr_mdlc_world_machines_building_biowaste_harvester_desc: "Biomass from Auto-Farms and other sources are diverted into tanks where anaerobic bacteria produce gases which can then be converted into energy.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_biowaste_harvester_desc: "Biomass from Auto-Farms and other sources are diverted into tanks where anaerobic bacteria produce gases which can then be converted into energy. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_bio_reactor_2 - TODO
  oxr_mdlc_world_machines_building_biowaste_harvester: "Bio-Gas Digester II"
- oxr_mdlc_world_machines_building_biowaste_harvester_desc: "Rows upon rows of tanks contain anaerobic bacteria that produce gases which can then be converted into energy. With the introduction of chemically treated alloys, additional instrumentation and refining equipment are able to capture small amounts of exotic gases.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_biowaste_harvester_desc: "Rows upon rows of tanks contain anaerobic bacteria that produce gases which can then be converted into energy. With the introduction of chemically treated alloys, additional instrumentation and refining equipment are able to capture small amounts of exotic gases. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
  ### DEPOSIT RESOURCE ###
  # building_mote_harvesters - TODO
  oxr_mdlc_world_machines_building_auto_mote_sink: "Mote Auto-Trap"
- oxr_mdlc_world_machines_building_auto_mote_sink_desc: "A series of sensitive magnetic plates direct already present volatile motes into a simple containment field for transfer.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_mote_sink_desc: "A series of sensitive magnetic plates direct already present volatile motes into a simple containment field for transfer. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # building_gas_extractors - TODO
  oxr_mdlc_world_machines_building_auto_gas_condenser: "Exotic Gas Auto-Condenser"
- oxr_mdlc_world_machines_building_auto_gas_condenser_desc: "This automated facility follows simple mining algorithms to reach the exotic gas deposits embedded in the planet's surface. It then cools the gases down to liquid form for transport. $oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_gas_condenser_desc: "This automated facility follows simple mining algorithms to reach the exotic gas deposits embedded in the planet's surface. It then cools the gases down to liquid form for transport.  $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # building_crystal_mines - TODO
  oxr_mdlc_world_machines_building_auto_crystal_extractor: "Rare Crystal Auto-Extractor"
- oxr_mdlc_world_machines_building_auto_crystal_extractor: "This automated facility follows simple mining algorithms to reach the rare crystal deposits embedded in the planet's surface.oxr_mdlc_world_machines_building_auto_crystal_extractor.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_crystal_extractor: "This automated facility follows simple mining algorithms to reach the rare crystal deposits embedded in the planet's surface.oxr_mdlc_world_machines_building_auto_crystal_extractor. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
  #### STRATEGIC RESOURCES ####
  # collider = motes
  oxr_mdlc_world_machines_building_particle_collider: "$oxr_gear$ Particle Collider"
- oxr_mdlc_world_machines_building_particle_collider_desc: "This facility has a large loop 25km in circumference, with six crossing points, twelve detectors, and two EM matter collection berms. Data from high-speed particle collisions are automatically logged, crunched, and any secondary resources, such as £volatile_motes£ §Y$volatile_motes$§! are harvested.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_particle_collider_desc: "This facility has a large loop 25km in circumference, with six crossing points, twelve detectors, and two EM matter collection berms. Data from high-speed particle collisions are automatically logged, crunched, and any secondary resources, such as £volatile_motes£ §Y$volatile_motes$§! are harvested. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # crytals -- requires 1k rare crystals to build
  oxr_mdlc_world_machines_building_crystal_cultivation_tank: "$oxr_gear$ Microfluidic Crystal Array"
- oxr_mdlc_world_machines_building_crystal_cultivation_tank_desc: "Plates of various alloys are first etched with fine channels, then a growing solution is seeded with a large amount of £rare_crystals£ §Y$rare_crystals$§!. The solution is dispersed onto the plates, which are arranged in long rows. Resources are harvested periodically, while some of the yield is reincorporated as seed material.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_crystal_cultivation_tank_desc: "Plates of various alloys are first etched with fine channels, then a growing solution is seeded with a large amount of £rare_crystals£ §Y$rare_crystals$§!. The solution is dispersed onto the plates, which are arranged in long rows. Resources are harvested periodically, while some of the yield is reincorporated as seed material. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
  # exotic gases - fewer minerals, plus biomass
  oxr_mdlc_world_machines_building_welding_colony: "$oxr_gear$ Welding Colony"
- oxr_mdlc_world_machines_building_welding_colony_desc: "Large amounts of alloys are exposed to a chemical welding process, which emits toxic fumes that feed a special bacteria in isolated chambers. The gaseous byproduct of the bacteria colonies is extracted, cleaned, and certified to be a 99 percent stable facsimile of £exotic_gases£ §Y$exotic_gases$§!.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_welding_colony_desc: "Large amounts of alloys are exposed to a chemical welding process, which emits toxic fumes that feed a special bacteria in isolated chambers. The gaseous byproduct of the bacteria colonies is extracted, cleaned, and certified to be a 99 percent stable facsimile of £exotic_gases£ §Y$exotic_gases$§!. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
  rikk_mdlc_world_machine_SR_building: "$oxr_gear$ Strategic Resource Filtering Module"
  rikk_mdlc_world_machine_SR_building_effect: "$xvcv_mdlc_world_machines_generator_districts$ £exotic_gases£ output: §G+0.2§!\n$xvcv_mdlc_world_machines_generator_districts$ £minerals£ upkeep: §R+2§!\n$xvcv_mdlc_world_machines_mining_districts$ £rare_crystals£ output: §G+0.2§!\n$xvcv_mdlc_world_machines_mining_districts$ £energy£ upkeep: §R+1§!\n$xvcv_mdlc_world_machines_food_districts$ £exotic_gases£ output: §G+0.2§!\n$xvcv_mdlc_world_machines_food_districts$ £energy£ upkeep: §R+1§!"
- rikk_mdlc_world_machine_SR_building_desc: "Processes and alters world machine detritus scrubbing techniques to allow it to collect trace amounts of strategic resources from our harvesting industries. Applied on a planetary scale, these trace amounts can add up to a greater whole."
+ rikk_mdlc_world_machine_SR_building_desc: "Processes and alters world machine detritus scrubbing techniques to allow it to collect trace amounts of strategic resources from our harvesting industries. Applied on a planetary scale, these trace amounts can add up to a greater whole.$oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
  #### UNITY ####
 # building_uplink_node
  oxr_mdlc_world_machines_building_auto_unity_1: "$oxr_gear$ Auto-Cohesion Supervisor Process"
- oxr_mdlc_world_machines_building_auto_unity_1_desc: "This data monitoring station records basic information about planetary processes, compiles reports, and directs administrative tasks.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_unity_1_desc: "This data monitoring station records basic information about planetary processes, compiles reports, and directs administrative tasks.$oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_network_junction
  oxr_mdlc_world_machines_building_auto_unity_2: "Auto-Cohesion Supervisor Hub"
- oxr_mdlc_world_machines_building_auto_unity_2_desc: "This large data monitoring station records detailed information about planetary processes, compiles reports, and directs administrative tasks.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_unity_2_desc: "This large data monitoring station records detailed information about planetary processes, compiles reports, and directs administrative tasks.$oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # building_system_conflux
  oxr_mdlc_world_machines_building_auto_unity_3: "Auto-Cohesion Supervisor Annex"
- oxr_mdlc_world_machines_building_auto_unity_3_desc: "This data monitoring tower records extremely detailed information about planetary processes, generates endless metadata, compiles reports, and directs administrative tasks.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_unity_3_desc: "This data monitoring tower records extremely detailed information about planetary processes, generates endless metadata, compiles reports, and directs administrative tasks.$oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # new
  oxr_mdlc_world_machines_building_auto_unity_4: "Auto-Cohesion Supervisor Nexus"
- oxr_mdlc_world_machines_building_auto_unity_4_desc: "This data monitoring tower records extremely detailed information about planetary processes, generates endless metadata, compiles reports, and directs administrative tasks.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_auto_unity_4_desc: "This data monitoring tower records extremely detailed information about planetary processes, generates endless metadata, compiles reports, and directs administrative tasks.$oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # Alpha hub alternative
  oxr_mdlc_world_machines_building_auto_unity_alpha_hub: "$oxr_gear$ Auto-Cohesion Amplifier"
- oxr_mdlc_world_machines_building_auto_unity_alpha_hub_desc: "This facility installs additional supervisor subroutines to $oxr_mdlc_growth_node$'s task processing library to improve empire-wide unity output."
+ oxr_mdlc_world_machines_building_auto_unity_alpha_hub_desc: "This facility installs additional supervisor subroutines to $oxr_mdlc_growth_node$'s task processing library to improve empire-wide unity output.$oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 
  #### UNIQUE ####
 # PRINT WMCS
  oxr_mdlc_world_machines_building_core_fabrication_depot: "$oxr_gear$ Auto-W.M.C Fabricator"
- oxr_mdlc_world_machines_building_core_fabrication_depot_desc: "This production center is 50 meters below ground, and 50 meters above, making it 100 meters tall; the size is necessary to accommodate all aspects of assembling ['concept_oxr_mdlc_world_machine_core_resource']s. One face of the structure is an enormous door for transporting completed cores out to storage. The production center has two large wings: one for fabricating the near-perpetual reactor, and the other for producing all other components. The center of the building is devoted solely to assembly. $oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_core_fabrication_depot_desc: "This production center is 50 meters below ground, and 50 meters above, making it 100 meters tall; the size is necessary to accommodate all aspects of assembling ['concept_oxr_mdlc_world_machine_core_resource']s. One face of the structure is an enormous door for transporting completed cores out to storage. The production center has two large wings: one for fabricating the near-perpetual reactor, and the other for producing all other components. The center of the building is devoted solely to assembly. $oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # STORE THEM
  oxr_mdlc_world_machines_building_storage_cradle: "$oxr_gear$ Auto-W.M.C Storage Cradle"
- oxr_mdlc_world_machines_building_storage_cradle_desc: "This structure is made of reinforced alloys and produces its own power in order to avoid damage to cores from fluctuations in the planetary power grid. However, it does require physics oversight to support maintaining stability of cores in storage.$oxr_mdlc_world_machine_building_category_note$"
+ oxr_mdlc_world_machines_building_storage_cradle_desc: "This structure is made of reinforced alloys and produces its own power in order to avoid damage to cores from fluctuations in the planetary power grid. However, it does require physics oversight to support maintaining stability of cores in storage.$oxr_mdlc_mod_tag$ $oxr_mdlc_world_machine_building_category_note$"
 # ORGANOID
  oxr_mdlc_building_auto_organoid_research_center: "$oxr_gear$ Auto-$oxr_mdlc_building_organoid_research_center$"
  oxr_mdlc_building_auto_organoid_research_center_desc: "$oxr_mdlc_building_organoid_research_center_desc$"


### PR DESCRIPTION
Hi there. I noticed some auto-building descriptions have `$oxr_mdlc_mod_tag$ ` or `$oxr_mdlc_world_machine_building_category_note` missing. According to my check, these buildings all should be automated popless building specific to world machines. So I added missing building category notes. I also removed some repeated building category notes. Thanks for updating, 和 apologies if I made some mistake.