### PR TITLE
MRE:C Patch 2.3.9

### DIFF
--- a/common/game_rules/oxr_mdlc_game_rules_overrides.txt
+++ b/common/game_rules/oxr_mdlc_game_rules_overrides.txt
@@ -198,3 +198,47 @@ can_species_be_assembled = {
 		country = root.owner
 	}
 }
+can_be_leader = {
+	has_citizenship_rights = yes
+	# Rule out Traits for servitude & lack of free will
+	NOR = {
+		has_trait = trait_syncretic_proles
+		can_think = no
+	}
+	OR = {
+		is_robot_pop = no
+		root = {
+			OR = {
+				has_technology = tech_synthetic_leaders
+				is_machine_empire = yes
+				is_mechanical_empire = yes
+				is_individual_machine = yes
+			}
+		}
+		# Machines & Robot Expansion -- includes root in trigger
+		oxr_mdlc_can_be_leader = yes
+	}
+	OR = {
+		is_same_species = root
+		root = {
+			NAND = {
+				has_origin = origin_necrophage
+				has_trait = trait_necrophage
+			}
+		}
+	}
+}
+#Checks whether this species is eligible to become rulers through elections
+#Root = country
+#This = species
+can_generate_leader_from_species = {
+	is_sapient = yes
+	OR = {
+		NAND = {
+			NOT = { root = { has_technology = "tech_synthetic_leaders" } }
+			has_trait = "trait_mechanical"
+		}
+		oxr_mdlc_can_generate_leader_from_species = yes
+		has_citizenship_type = { type = citizenship_full country = root }
+	}
+}

--- a/common/game_rules/oxr_mdlc_game_rules_overrides.txt
+++ b/common/game_rules/oxr_mdlc_game_rules_overrides.txt
@@ -35,6 +35,9 @@ can_release_vassal_from_species = {
 #Root = country
 #This = planet
 can_colonize_planet = {
+	hidden_trigger = {
+		exists = root
+	}
 	custom_tooltip = {
 		fail_text = "COLONIZATION_IMPOSSIBLE_UNDER_INVESTIGATION"
 		NOT = { has_planet_flag = planet_under_investigation }
@@ -69,6 +72,29 @@ can_colonize_planet = {
 			NOT = { owner = { has_event_chain = cosmogenesis_planet_pickup_chain } }
 		}
 	}
+	custom_tooltip = {
+		fail_text = "COLONIZATION_IMPOSSIBLE_CRIMSON_CRAWLERS"
+
+		if = {
+			limit = {
+				has_modifier = crimson_crawlers
+			}
+			root = {
+				cares_for_crimson_crawlers = yes
+			}
+		}
+	}
+
+	custom_tooltip = {
+		fail_text = "COLONIZATION_IMPOSSIBLE_DEFENDED_PLANET"
+		NOT = { has_planet_flag = planet_defended_forbid_colonization }
+	}
+
+	custom_tooltip = {
+		fail_text = "COLONIZATION_IMPOSSIBLE_SMEEGIBB_PLANET"
+		NOT = { has_planet_flag = cannot_colonize_smeegibb_shelter }
+	}
+
 	custom_tooltip = {
 		# Machine & Robot Expansion Continued
 		fail_text = oxr_mdlc_can_colonize_planet_pc_habitat.fail_active

--- a/common/inline_scripts/mod_compat/planetary_diversity/traits/pd_pc_machine_habitability.txt
+++ b/common/inline_scripts/mod_compat/planetary_diversity/traits/pd_pc_machine_habitability.txt
@@ -1,9 +1,0 @@
-triggered_planet_growth_habitability_modifier = {
-	potential = {
-		exists = owner
-		has_planetary_diversity = yes
-	}
-	pc_pd_machine_cave_habitability = 1.0
-	pc_pd_machine_superhabitable_habitability = 1.0
-	pc_pd_machine_tidally_locked_habitability = 1.0
-}

--- a/common/scripted_triggers/oxr_mdlc_merger_of_rules_triggers_compat.txt
+++ b/common/scripted_triggers/oxr_mdlc_merger_of_rules_triggers_compat.txt
@@ -11,6 +11,25 @@ oxr_mdlc_can_release_vassal_from_species = {
 	}
 }
 
+oxr_mdlc_can_be_leader = {
+	# Inclusive of species from this mod
+	root = {
+		oxr_mdlc_is_non_organic_empire = yes
+	}
+}
+
+oxr_mdlc_can_generate_leader_from_species = {
+	# remember this is in pop scope
+	AND = {
+		has_trait = "trait_mechanical"
+		root = {
+			OR = {
+				has_origin = xvcv_mdlc_origin_mechanical_heritage
+				has_origin = xvcv_mdlc_origin_synth_ascend
+			}
+		}
+	}
+}
 # is_robot_empire in vanilla means 'is this an assembled species / non-biological'
 # it is used a lot to distinguish assembled vs grown/cloned species
 # the terminology is not good so I am changing it,
@@ -18,9 +37,9 @@ oxr_mdlc_can_release_vassal_from_species = {
 
 oxr_mdlc_is_non_organic_empire = {
 	OR = {
-		owner_species = { has_trait = trait_mechanical }
-		oxr_mdlc_is_synthetic_empire = yes
-		oxr_mdlc_is_any_machine_empire = yes
+		owner_species = { has_trait = trait_mechanical }  # is_mechanical_empire
+		oxr_mdlc_is_synthetic_empire = yes  # include species from this mod
+		oxr_mdlc_is_any_machine_empire = yes  # gestalt or individual
 	}
 }
 

--- a/common/traits/!!!_oxr_mdlc_species_traits_vanilla_override.txt
+++ b/common/traits/!!!_oxr_mdlc_species_traits_vanilla_override.txt
@@ -30,6 +30,7 @@ trait_mechanical = {
 	triggered_planet_growth_habitability_modifier = {
 		potential = {
 			exists = owner
+			has_machines_robots_expac_continued = yes
 			# always = yes
 			owner = {
 				OR = {
@@ -42,5 +43,14 @@ trait_mechanical = {
 		xvcv_mdlc_pc_mechanical_habitability = 1  # MREC
 	}
 
-	inline_script = mod_compat/planetary_diversity/traits/pd_pc_machine_habitability
+	triggered_planet_growth_habitability_modifier = {
+		potential = {
+			exists = owner
+			has_planetary_diversity = yes
+		}
+		pc_pd_machine_cave_habitability = 1.0
+		pc_pd_machine_superhabitable_habitability = 1.0
+		pc_pd_machine_tidally_locked_habitability = 1.0
+	}
+
 }


### PR DESCRIPTION
- trait_mechanical compatibility fixes with PD
- explicitly override can_be_leader, can_generate_leader_from_species to include the 2 origins from this mod
- make overridden can_colonize_planet on par with vanilla