### PR TITLE
Patch 3.2.2 - small batch of updates

### DIFF
--- a/common/game_rules/oxr_mdlc_game_rules_overrides.txt
+++ b/common/game_rules/oxr_mdlc_game_rules_overrides.txt
@@ -122,3 +122,67 @@ can_generate_leader_from_species = {
 		has_citizenship_type = { type = citizenship_full country = root }
 	}
 }
+
+can_fill_ruler_job = {
+	if = {
+		limit = {
+			exists = owner
+			owner = {
+				has_origin = origin_necrophage
+				has_trait = trait_necrophage
+			}
+		}
+		custom_tooltip = {
+			text = RULER_JOB_NECROPHAGE_TRIGGER
+			has_trait = trait_necrophage
+			is_enslaved = no
+			is_being_purged = no
+			is_being_assimilated = no
+		}
+	}
+	else = {
+		custom_tooltip = RULER_JOB_TRIGGER
+		hidden_trigger = {
+			NOT = { has_ethic = ethic_gestalt_consciousness }
+			exists = owner
+			is_enslaved = no
+			is_being_purged = no
+			is_being_assimilated = no
+			NOT = { has_trait = trait_syncretic_proles }
+			# Rule out Traits for servitude & lack of free will
+			can_think = yes
+			# Rule out Disconnected Drones
+			has_disconnected_drone_citizenship_type = no
+			# Rule out Machine Pops, unless they're rendered sapient
+			OR = {
+				# Machine & Robot Expansion: Continued
+				oxr_mdlc_synths_can_fill_complex_job = yes
+
+				NOT = { has_trait = trait_mechanical }
+				AND = {
+					owner = { has_technology = tech_synthetic_workers }
+					owner = { has_policy_flag = ai_full_rights }
+				}
+			}
+			# Rule out Organic Trophies
+			NOR = {
+				has_citizenship_type = {
+					type = citizenship_organic_trophy
+					country = owner
+				}
+				has_citizenship_type = {
+					type = citizenship_cruise_passenger
+					country = owner
+				}
+			}
+			# Rule out violations of the 'Right to Work' Resolution (prioritises organic workers)
+			if = {
+				limit = {
+					divinity_right_to_work_job_check_trigger_exempt = no
+				}
+				divinity_right_to_work_job_check_trigger_ruler = yes
+			}
+		}
+	}
+}
+

--- a/common/on_actions/xvcv_mdlc_on_actions.txt
+++ b/common/on_actions/xvcv_mdlc_on_actions.txt
@@ -29,6 +29,7 @@ on_game_start_country = {
 	events = {
 		xvcv_mdlc.1 #on game start: starting condition adjustment
 		xvcv_mdlc.200  # mechanical heritage origin
+		xvcv_mdlc.210  # synth ascended origin start
 		xvcv_mdlc_origins.100  # xvcv_mdlc_origin_start_with_colony (after the doomsday)
 		xvcv_mdlc_espionage.1 #add 'xvcv_mdlc_leader_trait_civic_malware_machine' leader trait for a gestalt node when the game starts
 		xvcv_mdlc_config_effect.1 #set country flags for mod configurations

--- a/common/scripted_effects/oxr_mdlc_scripted_effects_synth_mechanical.txt
+++ b/common/scripted_effects/oxr_mdlc_scripted_effects_synth_mechanical.txt
@@ -118,22 +118,19 @@ oxr_mdlc_country_mechanical_heritage_origin_game_start_effect = {
 			food = 100
 		}
 	}
+}
 
-	# Balancing minerals
-	# if = {
-	# 	limit = {
-	# 		has_monthly_income = { resource = minerals value < 0 }
-	# 		capital_scope = {
-	# 			num_districts = {
-	# 				type = any
-	# 				value < 10
-	# 			}
-	# 		}
-	# 	}
-	# 	capital_scope = {
+oxr_mdlc_country_synth_ascended_origin_game_start_effect = {
 
-	# 		add_district = xvcv_mdlc_pc_mechanical_district_mining
-	# 	}
-	# 	log = "\\[prev.GetName] Found mineral deficit, added two mining districts"
-	# }
+	owner = {
+		give_technology = { tech = tech_synthetic_workers message = no }
+
+		set_country_flag = synthetic_empire
+		set_policy = {
+			policy = artificial_intelligence_policy
+			option = ai_full_rights
+			cooldown = yes
+		}
+	}
+
 }

--- a/common/scripted_triggers/oxr_mdlc_merger_of_rules_triggers_compat.txt
+++ b/common/scripted_triggers/oxr_mdlc_merger_of_rules_triggers_compat.txt
@@ -56,6 +56,16 @@ oxr_mdlc_can_generate_leader_from_species = {
 		}
 	}
 }
+
+oxr_mdlc_synths_can_fill_complex_job = {
+	owner = { oxr_mdlc_has_mechanical_origin = yes }
+	OR = {
+		is_species_class = XVCV_MDLC_ROBOT
+		is_species_class = XVCV_MDLC_BIO_ROBOT  # not technically Synth
+	}
+}
+
+
 # is_robot_empire in vanilla means 'is this an assembled species / non-biological'
 # it is used a lot to distinguish assembled vs grown/cloned species
 # the terminology is not good so I am changing it,

--- a/common/scripted_triggers/oxr_mdlc_scripted_triggers_vanilla_overrides.txt
+++ b/common/scripted_triggers/oxr_mdlc_scripted_triggers_vanilla_overrides.txt
@@ -86,6 +86,7 @@ can_be_leader = {
 	}
 }
 
+
 can_colonize_planet_trigger = {
 	custom_tooltip = {
 		fail_text = "COLONIZATION_IMPOSSIBLE_UNDER_INVESTIGATION"
@@ -174,113 +175,5 @@ can_colonize_planet_trigger = {
 		# Machine & Robot Expansion Continued
 		fail_text = oxr_mdlc_can_colonize_planet.planet_being_decomposed
 		NOT = { has_planet_flag = oxr_mdlc_origin_null_stellar_formatter_placed }
-	}
-}
-
-# Overwritten bc Mechanical origin pops could not work specialist jobs after a base game update
-can_fill_specialist_job_trigger = {
-	custom_tooltip = SPECIALIST_JOB_TRIGGER
-	hidden_trigger = {
-		NOT = { has_ethic = ethic_gestalt_consciousness }
-		exists = owner
-		OR = {
-			is_enslaved = no
-			has_slavery_type = { type = slavery_indentured }
-		}
-		is_being_purged = no
-		is_being_assimilated = no
-		NOT = { has_trait = trait_syncretic_proles }
-		# Rule out Traits for servitude & lack of free will
-		can_think = yes
-		NOT = {	has_pop_group_flag = cant_work }
-		# Rule out Disconnected Drones
-		has_disconnected_drone_citizenship_type = no
-		OR = {
-			# Machine & Robot Expansion: Continued - if empire has 2 origins or custom owner species
-			oxr_mdlc_pop_can_fill_advanced_job_trigger = yes
-			NOT = { has_trait = trait_mechanical }
-			owner = { has_technology = tech_droid_workers }
-		}
-		NOR = {
-			has_citizenship_type = {
-				type = citizenship_organic_trophy
-				country = owner
-			}
-			has_citizenship_type = {
-				type = citizenship_cruise_passenger
-				country = owner
-			}
-		}
-		if = {
-			limit = {
-				divinity_right_to_work_job_check_trigger_exempt = no
-			}
-			divinity_right_to_work_job_check_trigger_specialist = yes
-		}
-	}
-}
-
-#this/root = pop
-#checked if job's possible_precalc = can_fill_ruler_job
-# Overwritten bc Mechanical origin pops could not work specialist jobs after a base game update
-can_fill_ruler_job = {
-	if = {
-		limit = {
-			exists = owner
-			owner = {
-				has_origin = origin_necrophage
-				has_trait = trait_necrophage
-			}
-		}
-		custom_tooltip = {
-			text = RULER_JOB_NECROPHAGE_TRIGGER
-			has_trait = trait_necrophage
-			is_enslaved = no
-			is_being_purged = no
-			is_being_assimilated = no
-		}
-	}
-	else = {
-		custom_tooltip = RULER_JOB_TRIGGER
-		hidden_trigger = {
-			NOT = { has_ethic = ethic_gestalt_consciousness }
-			exists = owner
-			is_enslaved = no
-			is_being_purged = no
-			is_being_assimilated = no
-			NOT = { has_trait = trait_syncretic_proles }
-			# Rule out Traits for servitude & lack of free will
-			can_think = yes
-			# Rule out Disconnected Drones
-			has_disconnected_drone_citizenship_type = no
-			# Rule out Machine Pops, unless they're rendered sapient
-			OR = {
-				# Machine & Robot Expansion: Continued check - let synth empires & custom origin pops work ruler jobs
-				oxr_mdlc_pop_can_fill_advanced_job_trigger = yes
-				NOT = { has_trait = trait_mechanical }
-				AND = {
-					owner = { has_technology = tech_synthetic_workers }
-					owner = { has_policy_flag = ai_full_rights }
-				}
-			}
-			# Rule out Organic Trophies
-			NOR = {
-				has_citizenship_type = {
-					type = citizenship_organic_trophy
-					country = owner
-				}
-				has_citizenship_type = {
-					type = citizenship_cruise_passenger
-					country = owner
-				}
-			}
-			# Rule out violations of the 'Right to Work' Resolution (prioritises organic workers)
-			if = {
-				limit = {
-					divinity_right_to_work_job_check_trigger_exempt = no
-				}
-				divinity_right_to_work_job_check_trigger_ruler = yes
-			}
-		}
 	}
 }

--- a/common/scripted_triggers/oxr_mdlc_scripted_triggers_vanilla_overrides_synths.txt
+++ b/common/scripted_triggers/oxr_mdlc_scripted_triggers_vanilla_overrides_synths.txt
@@ -1,0 +1,191 @@
+## These are for supporting Synth species from this mod's origins
+## oxr_mdlc_synths_can_fill_complex_job = yes <-- main trigger
+
+## We have to get around all the code blocking non-sapient robots
+## from working complex jobs.
+
+can_fill_specialist_job_trigger = {
+	custom_tooltip = SPECIALIST_JOB_TRIGGER
+	hidden_trigger = {
+		NOT = { has_ethic = ethic_gestalt_consciousness }
+		exists = owner
+		OR = {
+			is_enslaved = no
+			has_slavery_type = { type = slavery_indentured }
+		}
+		is_being_purged = no
+		is_being_assimilated = no
+		NOT = { has_trait = trait_syncretic_proles }
+		# Rule out Traits for servitude & lack of free will
+		can_think = yes
+		NOT = {	has_pop_group_flag = cant_work }
+		# Rule out Disconnected Drones
+		has_disconnected_drone_citizenship_type = no
+		OR = {
+			# Machine & Robot Expansion: Continued
+			oxr_mdlc_synths_can_fill_complex_job = yes
+
+			NOT = { has_trait = trait_mechanical }
+			owner = { has_technology = tech_droid_workers }
+		}
+		NOR = {
+			has_citizenship_type = {
+				type = citizenship_organic_trophy
+				country = owner
+			}
+			has_citizenship_type = {
+				type = citizenship_cruise_passenger
+				country = owner
+			}
+		}
+		if = {
+			limit = {
+				divinity_right_to_work_job_check_trigger_exempt = no
+			}
+			divinity_right_to_work_job_check_trigger_specialist = yes
+		}
+	}
+}
+
+entertainer_job_check_trigger = {
+	custom_tooltip = SPECIALIST_JOB_TRIGGER
+	hidden_trigger = {
+		exists = owner
+		OR = {
+			is_enslaved = no
+			has_slavery_type = { type = slavery_domestic }
+		}
+		is_being_purged = no
+		is_being_assimilated = no
+		# Rule out Traits for servitude & lack of free will
+		can_think = yes
+		# Rule out Disconnected Drones
+		has_disconnected_drone_citizenship_type = no
+		OR = {
+			# Machine & Robot Expansion: Continued
+			oxr_mdlc_synths_can_fill_complex_job = yes
+
+			NOT = { has_trait = trait_mechanical }
+			owner = { has_technology = tech_droid_workers }
+		}
+		NOR = {
+			has_citizenship_type = {
+				type = citizenship_organic_trophy
+				country = owner
+			}
+			has_citizenship_type = {
+				type = citizenship_cruise_passenger
+				country = owner
+			}
+		}
+		if = {
+			limit = {
+				divinity_right_to_work_job_check_trigger_exempt = no
+			}
+			divinity_right_to_work_job_check_trigger_specialist = yes
+		}
+	}
+}
+
+complex_specialist_job_check_trigger = {
+	hidden_trigger = {
+		exists = owner
+		OR = {
+			# Machine & Robot Expansion: Continued
+			oxr_mdlc_synths_can_fill_complex_job = yes
+
+			NOT = { has_trait = trait_mechanical }
+			AND = {
+				owner = { has_technology = tech_droid_workers }
+				owner = { NOT = { has_policy_flag = ai_outlawed } }
+			}
+		}
+	}
+}
+
+entertainer_job_check_trigger = {
+	custom_tooltip = SPECIALIST_JOB_TRIGGER
+	hidden_trigger = {
+		exists = owner
+		OR = {
+			is_enslaved = no
+			has_slavery_type = { type = slavery_domestic }
+		}
+		is_being_purged = no
+		is_being_assimilated = no
+		# Rule out Traits for servitude & lack of free will
+		can_think = yes
+		# Rule out Disconnected Drones
+		has_disconnected_drone_citizenship_type = no
+		OR = {
+			# Machine & Robot Expansion: Continued
+			oxr_mdlc_synths_can_fill_complex_job = yes
+
+			NOT = { has_trait = trait_mechanical }
+			owner = { has_technology = tech_droid_workers }
+		}
+		NOR = {
+			has_citizenship_type = {
+				type = citizenship_organic_trophy
+				country = owner
+			}
+			has_citizenship_type = {
+				type = citizenship_cruise_passenger
+				country = owner
+			}
+		}
+		if = {
+			limit = {
+				divinity_right_to_work_job_check_trigger_exempt = no
+			}
+			divinity_right_to_work_job_check_trigger_specialist = yes
+		}
+	}
+}
+
+# ENFORCER not battle thrall >:/
+
+battle_thrall_job_check_trigger = {
+	custom_tooltip = BATTLE_THRALL_JOB_TRIGGER
+	hidden_trigger = {
+		exists = owner
+		OR = {
+			is_enslaved = no
+			has_slavery_type = { type = slavery_military }
+		}
+		is_being_purged = no
+		is_being_assimilated = no
+		# Rule out Traits for servitude & lack of free will
+		can_think = yes
+		# Rule out Disconnected Drones
+		has_disconnected_drone_citizenship_type = no
+		NOT = {
+			has_military_service_type = {
+				type = military_service_none
+			}
+		}
+		OR = {
+			# Machine & Robot Expansion: Continued
+			oxr_mdlc_synths_can_fill_complex_job = yes
+
+			NOT = { has_trait = trait_mechanical }
+			owner = { has_technology = tech_droid_workers }
+		}
+		NOR = {
+			has_citizenship_type = {
+				type = citizenship_organic_trophy
+				country = owner
+			}
+			has_citizenship_type = {
+				type = citizenship_cruise_passenger
+				country = owner
+			}
+		}
+		if = {
+			limit = {
+				divinity_right_to_work_job_check_trigger_exempt = no
+			}
+			divinity_right_to_work_job_check_trigger_specialist = yes
+		}
+	}
+}

--- a/common/technology/oxr_mdlc_tech.txt
+++ b/common/technology/oxr_mdlc_tech.txt
@@ -142,6 +142,7 @@ oxr_mdlc_tech_machine_species_points_picks_repeatable = {
 	potential = {
 		has_authority = auth_machine_intelligence
 		has_paragon_dlc = yes
+		has_country_flag = oxr_mdlc_country_feature_infinite_repeatable_builder_techs
 	}
 	prerequisites = {
 		"tech_self_assembling_components"  # T3 Eng
@@ -209,5 +210,40 @@ oxr_mdlc_tech_mechanical_species_points_picks_repeatable = {
 	modifier = {
 		ROBOT_species_trait_picks_add = 1
 		ROBOT_species_trait_points_add = 2
+	}
+}
+
+oxr_mdlc_tech_bio_mechanical_species_points_picks_repeatable = {
+	icon = oxr_mdlc_tech_machine_species_points_picks_repeatable
+	area = engineering
+	cost = 250000
+	cost_per_level = 25000
+	tier = @repeatableTechTier
+	category = { industry }
+	levels = -1 #5% x 10 = 50% #use '-1' value for infinite researching
+	weight = @repeatableTechWeight
+
+	potential = {
+		oxr_mdlc_country_is_finished_bio_mech = yes
+	}
+
+	weight_modifier = {
+		factor = @repatableTechFactor
+	}
+	
+	ai_weight = {
+		factor = 1.0
+	}
+
+	weight_groups = {
+		repeatable
+	}
+	mod_weight_if_group_picked = {
+		repeatable = 0.01
+	}
+
+	modifier = {
+		XVCV_MDLC_BIO_ROBOT_species_trait_picks_add = 1
+		XVCV_MDLC_BIO_ROBOT_species_trait_points_add = 2
 	}
 }

--- a/common/technology/oxr_mdlc_tech.txt
+++ b/common/technology/oxr_mdlc_tech.txt
@@ -140,9 +140,8 @@ oxr_mdlc_tech_machine_species_points_picks_repeatable = {
 	weight = @repeatableTechWeight
 
 	potential = {
-		has_authority = auth_machine_intelligence
+		oxr_mdlc_is_any_machine_empire = yes
 		has_paragon_dlc = yes
-		has_country_flag = oxr_mdlc_country_feature_infinite_repeatable_builder_techs
 	}
 	prerequisites = {
 		"tech_self_assembling_components"  # T3 Eng

--- a/events/xvcv_mdlc_events_main.txt
+++ b/events/xvcv_mdlc_events_main.txt
@@ -361,6 +361,7 @@ country_event = {
 
 	trigger = {
 		has_xvcv_mdlc_origin_mechanical_heritage = yes
+
 		# Don't want this firing multiple times
 		doesnt_have_country_flag = { FLAG = xvcv_mdlc_origin_mechanical_heritage_empire }
 	}
@@ -368,6 +369,22 @@ country_event = {
 	immediate = {
 		log = "Starting game setup effects for Mechanical Origin empire \\[This.GetName] "
 		oxr_mdlc_country_mechanical_heritage_origin_game_start_effect = yes
+	}
+}
+
+# Do game start things for Synthetic Ascended origin
+country_event = {
+	id = xvcv_mdlc.210
+	hide_window = yes
+	is_triggered_only = yes
+
+	trigger = {
+		has_xvcv_mdlc_origin_synth_ascend = yes
+	}
+
+	immediate = {
+		log = "Starting game setup effects for Synth Origin empire \\[This.GetName] "
+		oxr_mdlc_country_synth_ascended_origin_game_start_effect = yes
 	}
 }
 

--- a/localisation/english/oxr_mdlc_l_english_councilor_editor.yml
+++ b/localisation/english/oxr_mdlc_l_english_councilor_editor.yml
@@ -97,3 +97,5 @@
  oxr_mdlc_tech_machine_species_points_picks_repeatable_desc: "Retrospective analysis of Machine shell architecture to find even more spaces in Machine units where additional expansion interfaces can be installed.$oxr_mdlc_mod_tag$"
  oxr_mdlc_tech_mechanical_species_points_picks_repeatable: "Mechanical Instruction Architecture Expansion"
  oxr_mdlc_tech_mechanical_species_points_picks_repeatable_desc: "Retrospective analysis of Machine shell architecture to find even more spaces in Mechanical units where additional expansion interfaces can be installed.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_tech_bio_mechanical_species_points_picks_repeatable: "Bio-Mechanical Instruction Architecture Expansion"
+ oxr_mdlc_tech_bio_mechanical_species_points_picks_repeatable_desc: "Retrospective analysis of Bio-Mechanical architecture to find even more spaces in hybridized units where additional expansion interfaces can be installed.$oxr_mdlc_mod_tag$"

--- a/mrec_tools/features/councilor_editor/localisation/english/oxr_mdlc_l_english_councilor_editor.yml
+++ b/mrec_tools/features/councilor_editor/localisation/english/oxr_mdlc_l_english_councilor_editor.yml
@@ -96,4 +96,6 @@
  oxr_mdlc_tech_machine_species_points_picks_repeatable: "Machine Instruction Architecture Expansion"
  oxr_mdlc_tech_machine_species_points_picks_repeatable_desc: "Retrospective analysis of Machine shell architecture to find even more spaces in Machine units where additional expansion interfaces can be installed.$oxr_mdlc_mod_tag$"
  oxr_mdlc_tech_mechanical_species_points_picks_repeatable: "Mechanical Instruction Architecture Expansion"
- oxr_mdlc_tech_mechanical_species_points_picks_repeatable_desc: "Retrospective analysis of Machine shell architecture to find even more spaces in Mechanical units where additional expansion interfaces can be installed.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_tech_mechanical_species_points_picks_repeatable_desc: "Retrospective analysis of Synthetic shell architecture to find even more spaces in Synthetic units where additional expansion interfaces can be installed.$oxr_mdlc_mod_tag$"
+ oxr_mdlc_tech_bio_mechanical_species_points_picks_repeatable: "Bio-Mechanical Instruction Architecture Expansion"
+ oxr_mdlc_tech_bio_mechanical_species_points_picks_repeatable_desc: "Retrospective analysis of Bio-Mechanical architecture to find even more spaces in hybridized units where additional expansion interfaces can be installed.$oxr_mdlc_mod_tag$"


### PR DESCRIPTION
- Fix issues with Synths not being able to work complex jobs, by overriding job check triggers, since Mechanical species (non-sapient robots) are excluded by default here
- Add repeatable species points/picks tech for Bio-Mechanical species
- Individual Machine empire can research species points/pick tech for Machine species

Overridden game rules/triggers:

- can_fill_specialist_job_trigger
- entertainer_job_check_trigger
- complex_specialist_job_check_trigger
- entertainer_job_check_trigger
- battle_thrall_job_check_trigger
- can_fill_ruler_job